### PR TITLE
fix(layout): add missing noscript layout partial

### DIFF
--- a/core/templates/layout.noscript.warning.php
+++ b/core/templates/layout.noscript.warning.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * SPDX-FileCopyrightText: 2017-2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-FileCopyrightText: 2015 ownCloud, Inc.
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+?>
+<noscript>
+	<div id="nojavascript">
+		<div>
+			<?php print_unescaped(str_replace(
+				['{linkstart}', '{linkend}'],
+				['<a href="https://www.enable-javascript.com/" target="_blank" rel="noreferrer noopener">', '</a>'],
+				$l->t('This application requires JavaScript for correct operation. Please {linkstart}enable JavaScript{linkend} and reload the page.')
+			)); ?>
+		</div>
+	</div>
+</noscript>


### PR DESCRIPTION
Caused error in `nextcloud.log`

```
include(): Failed opening 'layout.noscript.warning.php' for inclusion (include_path='/var/www/html/3rdparty/pear/archive_tar:/var/www/html/3rdparty/pear/console_getopt:/var/www/html/3rdparty/pear/pear-core-minimal/src:/var/www/html/3rdparty/pear/pear_exception:/var/www/html/apps:/var/www/html/apps-custom:/var/www/html/apps-external') at /var/www/html/themes/nc-ionos-theme/core/templates/layout.user.php#59
```

